### PR TITLE
chore: rename repo from clang-tools to clang-tools-docker

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,25 +1,26 @@
-name: Publish image to ghcr.io
+name: Publish images to ghcr.io
 
 on:
   workflow_dispatch:
     inputs:
       tag:
         description: 'which tag to publish'
-        default: 'all'
+        default: 'all 16 15 14 13 12 11 10 9 8'
         required: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Download image
-        run: |
-          docker pull xianpengshen/clang-tools:${{ inputs.tag }}
-          docker tag xianpengshen/clang-tools:${{ inputs.tag }} ghcr.io/cpp-linter/clang-tools:${{ inputs.tag }}
       - name: Login container registry
         run: |
           echo $CR_PAT | docker login ghcr.io -u shenxianpeng --password-stdin
         env:
           CR_PAT: ${{ secrets.CR_PAT }}
-      - name: Push image to container registry
-        run: docker push ghcr.io/cpp-linter/clang-tools:${{ inputs.tag }}
+      - name: Download and push image to ghcr.io
+        run: |
+          for tag in ${{ inputs.tag }}; do
+            docker pull xianpengshen/clang-tools:$tag
+            docker tag xianpengshen/clang-tools:$tag ghcr.io/cpp-linter/clang-tools:$tag
+            docker push ghcr.io/cpp-linter/clang-tools:$tag
+          done

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/11-alpine-3.14/Dockerfile
+++ b/11-alpine-3.14/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.14
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/12-alpine-3.15/Dockerfile
+++ b/12-alpine-3.15/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.15
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/14/Dockerfile
+++ b/14/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/15/Dockerfile
+++ b/15/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/16/Dockerfile
+++ b/16/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,31 @@
 # Clang Tools Docker image
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/xianpengshen/clang-tools)](https://hub.docker.com/r/xianpengshen/clang-tools)
-[![GitHub Repo](https://img.shields.io/badge/GitHub%20Repo-URL-blue?logo=github)](https://github.com/cpp-linter/clang-tools)
+[![GitHub Repo](https://img.shields.io/badge/GitHub%20Repo-URL-blue?logo=github)](https://github.com/cpp-linter/clang-tools-docker)
 ![Maintenance](https://img.shields.io/maintenance/yes/2023)
-[![CI](https://github.com/cpp-linter/clang-tools/actions/workflows/build-test-publish.yml/badge.svg)](https://github.com/cpp-linter/clang-tools/actions/workflows/build-test-publish.yml)
-[![Snyk Container](https://github.com/cpp-linter/clang-tools/actions/workflows/snyk-container-analysis.yml/badge.svg)](https://github.com/cpp-linter/clang-tools/actions/workflows/snyk-container-analysis.yml)
+[![CI](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/build-test-publish.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/build-test-publish.yml)
+[![Snyk Container](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/snyk-container-analysis.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/snyk-container-analysis.yml)
 
 🐳 The Clang Tools Docker image includes the clang-format and clang-tidy.
 
 ## Supported tags and respective `Dockerfile` links
 
-Docker Hub [registry](https://hub.docker.com/r/xianpengshen/clang-tools)
+You can find clang-tools docker images on Docker Hub [registry](https://hub.docker.com/r/xianpengshen/clang-tools) or GitHub Packages [registry](https://github.com/cpp-linter/clang-tools-docker/pkgs/container/clang-tools)
 
-* [`all`](https://github.com/cpp-linter/clang-tools/blob/master/all/Dockerfile) (include tags `16`, `15`, `14`, `13`, `12`, `11`, `10`, `9`, `8`)
-* [`16`](https://github.com/cpp-linter/clang-tools/blob/master/16/Dockerfile)
-* [`15`](https://github.com/cpp-linter/clang-tools/blob/master/15/Dockerfile)
-* [`14`](https://github.com/cpp-linter/clang-tools/blob/master/14/Dockerfile)
-* [`13`](https://github.com/cpp-linter/clang-tools/blob/master/13/Dockerfile)
-* [`12-alpine-edge`](https://github.com/cpp-linter/clang-tools/blob/master/12/alpine-edge/Dockerfile)
-* [`12`](https://github.com/cpp-linter/clang-tools/blob/master/12/Dockerfile)
-* [`11-alpine-3.14`](https://github.com/cpp-linter/clang-tools/blob/master/11/alpine-3.14/Dockerfile)
-* [`11`](https://github.com/cpp-linter/clang-tools/blob/master/11/Dockerfile)
-* [`10`](https://github.com/cpp-linter/clang-tools/blob/master/10/Dockerfile)
-* [`9`](https://github.com/cpp-linter/clang-tools/blob/master/9/Dockerfile)
-* [`8`](https://github.com/cpp-linter/clang-tools/blob/master/8/Dockerfile)
-* [`7`](https://github.com/cpp-linter/clang-tools/blob/master/7/Dockerfile)
-* [`6`](https://github.com/cpp-linter/clang-tools/blob/master/6/Dockerfile)
-
-GitHub Packages [registry](https://github.com/cpp-linter/clang-tools/pkgs/container/clang-tools)
-
-* [`all`](https://github.com/cpp-linter/clang-tools/blob/master/all/Dockerfile) (include tags `16`, `15`, `14`, `13`, `12`, `11`, `10`, `9`, `8`)
+* [`all`](https://github.com/cpp-linter/clang-tools-docker/blob/master/all/Dockerfile) (include tags `16`, `15`, `14`, `13`, `12`, `11`, `10`, `9`, `8`)
+* [`16`](https://github.com/cpp-linter/clang-tools-docker/blob/master/16/Dockerfile)
+* [`15`](https://github.com/cpp-linter/clang-tools-docker/blob/master/15/Dockerfile)
+* [`14`](https://github.com/cpp-linter/clang-tools-docker/blob/master/14/Dockerfile)
+* [`13`](https://github.com/cpp-linter/clang-tools-docker/blob/master/13/Dockerfile)
+* [`12-alpine-edge`](https://github.com/cpp-linter/clang-tools-docker/blob/master/12/alpine-edge/Dockerfile)
+* [`12`](https://github.com/cpp-linter/clang-tools-docker/blob/master/12/Dockerfile)
+* [`11-alpine-3.14`](https://github.com/cpp-linter/clang-tools-docker/blob/master/11/alpine-3.14/Dockerfile)
+* [`11`](https://github.com/cpp-linter/clang-tools-docker/blob/master/11/Dockerfile)
+* [`10`](https://github.com/cpp-linter/clang-tools-docker/blob/master/10/Dockerfile)
+* [`9`](https://github.com/cpp-linter/clang-tools-docker/blob/master/9/Dockerfile)
+* [`8`](https://github.com/cpp-linter/clang-tools-docker/blob/master/8/Dockerfile)
+* [`7`](https://github.com/cpp-linter/clang-tools-docker/blob/master/7/Dockerfile)
+* [`6`](https://github.com/cpp-linter/clang-tools-docker/blob/master/6/Dockerfile)
 
 ## How to use this image
 
@@ -55,7 +51,7 @@ $ docker run -v $PWD:/src xianpengshen/clang-tools:12 clang-tidy helloworld.c \
 -checks=boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,clang-analyzer-cplusplus-*,clang-analyzer-*,cppcoreguidelines-*
 ```
 
-### As base image in [`Dockerfile`](https://github.com/cpp-linter/clang-tools/blob/master/demo/Dockerfile)
+### As base image in [`Dockerfile`](https://github.com/cpp-linter/clang-tools-docker/blob/master/demo/Dockerfile)
 
 ```Dockerfile
 FROM xianpengshen/clang-tools:12
@@ -113,8 +109,8 @@ Status: Downloaded newer image for xianpengshen/clang-tools:11
 
 ## Have question or feedback?
 
-To provide feedback (requesting a feature or reporting a bug) please post to [issues](https://github.com/cpp-linter/clang-tools/issues).
+To provide feedback (requesting a feature or reporting a bug) please post to [issues](https://github.com/cpp-linter/clang-tools-docker/issues).
 
 ## License
 
-[Apache License](https://github.com/cpp-linter/clang-tools/blob/master/LICENSE)
+[Apache License](https://github.com/cpp-linter/clang-tools-docker/blob/master/LICENSE)

--- a/all/Dockerfile
+++ b/all/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools"
+LABEL org.opencontainers.image.source="https://github.com/cpp-linter/clang-tools-docker"
 LABEL org.opencontainers.image.description="The Clang Tools Docker image includes the clang-format and clang-tidy."
 LABEL org.opencontainers.image.licenses="MIT"
 


### PR DESCRIPTION
1. rename repo from clang-tools to clang-tools-docker
2. update publish-image.yml to support publishing all images to ghcr.io