### PR TITLE
Update dependabot.yml to remove reviewers option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     directory: /
     schedule:
       interval: "weekly"
-    reviewers:
-      - "shenxianpeng"
     groups:
       docker:
         patterns:
@@ -21,8 +19,6 @@ updates:
     directory: /
     schedule:
       interval: "weekly"
-    reviewers:
-      - "shenxianpeng"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Dependabot is now posting this comment as a warning:

> The reviewers field in the dependabot.yml file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see this [blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).