### PR TITLE
chore: migrate CI pipeline from master to main branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 'Dockerfile*'
       - 'docker-bake.hcl'
       - '.github/workflows/CI.yml'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 'Dockerfile*'
       - 'docker-bake.hcl'
@@ -56,15 +56,15 @@ jobs:
         run: docker buildx bake --file docker-bake.hcl ${{ matrix.target }}
 
       - name: Login container registries
-        if: github.ref == 'refs/heads/master' && github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           echo '${{ secrets.DOCKER_PASSWORD }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
 
       - name: Publish image for tag ${{ matrix.target }}
-        if: github.ref == 'refs/heads/master' && github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
         run: docker buildx bake --file docker-bake.hcl ${{ matrix.target }} --push
 
       - name: Remove builder instances
-        if: github.ref == 'refs/heads/master' && github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
         run: docker buildx rm --all-inactive --force

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -3,7 +3,7 @@ name: Update Docker Hub Description
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - README.md
       - .github/workflows/dockerhub-description.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - "master"
+      - "main"
   workflow_dispatch:
 
 permissions: {}
@@ -15,4 +15,4 @@ jobs:
       pull-requests: read
     uses: cpp-linter/.github/.github/workflows/release-drafter.yml@main
     with:
-      commitish: master
+      commitish: main

--- a/.github/workflows/snyk-container-analysis.yml
+++ b/.github/workflows/snyk-container-analysis.yml
@@ -10,12 +10,12 @@ name: Snyk Container
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 'Dockerfile*'
       - '.github/workflows/snyk-container-analysis.yml'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 'Dockerfile*'
       - '.github/workflows/snyk-container-analysis.yml'


### PR DESCRIPTION
Replace all hardcoded 'master' branch references with 'main' in:
- CI.yml (trigger branches + refs/heads/main conditions)
- snyk-container-analysis.yml (trigger branches)
- release-drafter.yml (trigger branch + commitish)
- dockerhub-description.yml (trigger branch)