### PR TITLE
fix: skip snyk job when SNYK_TOKEN is unavailable

### DIFF
--- a/.github/workflows/snyk-container-analysis.yml
+++ b/.github/workflows/snyk-container-analysis.yml
@@ -26,6 +26,7 @@ permissions:
 
 jobs:
   snyk:
+    if: ${{ secrets.SNYK_TOKEN != '' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1
@@ -44,6 +45,7 @@ jobs:
         args: --severity-threshold=high --file=Dockerfile
 
     - name: Upload result to GitHub Code Scanning
+      if: hashFiles('snyk.sarif') != ''
       uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         sarif_file: snyk.sarif


### PR DESCRIPTION
## Problem

The `snyk` CI job fails for PRs from Dependabot and forked repos because `SNYK_TOKEN` is not available to those PRs (GitHub security restriction). The job fails at the upload-sarif step with:

```
Error: Path does not exist: snyk.sarif
```

This blocks PRs like `dependabot/github_actions/actions-09392e188c` (#121) from getting a clean CI pass.

## Fix

- **Job-level guard**: Skip the entire snyk job when `secrets.SNYK_TOKEN` is empty
- **Upload guard**: Only run the upload-sarif step if `snyk.sarif` actually exists (safety net for any other snyk failures)

## Result

The snyk job will be skipped with a green status for Dependabot/fork PRs, and will continue to work normally for PRs from repo branches.