### PR TITLE
feat: add SBOM generation and cosign signing to CI pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  id-token: write  # Required for cosign keyless signing
+  packages: write
+
 jobs:
   extract-targets:
     runs-on: ubuntu-latest
@@ -61,9 +66,22 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           echo '${{ secrets.DOCKER_PASSWORD }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
 
-      - name: Publish image for tag ${{ matrix.target }}
+      - name: Publish image for tag ${{ matrix.target }} (with SBOM + provenance)
         if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
-        run: docker buildx bake --file docker-bake.hcl ${{ matrix.target }} --push
+        run: |
+          docker buildx bake --file docker-bake.hcl ${{ matrix.target }} --push \
+            --set "*.attest=type=sbom" \
+            --set "*.attest=type=provenance,mode=max"
+
+      - name: Install cosign
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
+        uses: sigstore/cosign-installer@c23eefbfe2b4653e89cd2fe1e09dd3e2a71ee69a # v3.11.0
+
+      - name: Sign images with cosign (keyless)
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
+        run: |
+          cosign sign --yes ghcr.io/cpp-linter/clang-tools:${{ matrix.target }}
+          cosign sign --yes xianpengshen/clang-tools:${{ matrix.target }}
 
       - name: Remove builder instances
         if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,8 +21,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write  # Required for cosign keyless signing
-  packages: write
 
 jobs:
   extract-targets:
@@ -42,6 +40,10 @@ jobs:
   build:
     needs: extract-targets
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for cosign keyless signing
+      packages: write
     strategy:
       matrix:
         target: ${{ fromJson(needs.extract-targets.outputs.targets) }}
@@ -75,7 +77,7 @@ jobs:
 
       - name: Install cosign
         if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
-        uses: sigstore/cosign-installer@c23eefbfe2b4653e89cd2fe1e09dd3e2a71ee69a # v3.11.0
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Sign images with cosign (keyless)
         if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# Clang Tools Docker image
+# 🐳 Clang Tools Docker image
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/xianpengshen/clang-tools)](https://hub.docker.com/r/xianpengshen/clang-tools)
 [![Docker Image Size](https://img.shields.io/docker/image-size/xianpengshen/clang-tools/22)](https://hub.docker.com/r/xianpengshen/clang-tools/tags)
-[![GitHub Repo](https://img.shields.io/badge/GitHub%20Repo-URL-blue?logo=github)](https://github.com/cpp-linter/clang-tools-docker)
 [![CI](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/CI.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/CI.yml)
 [![Docker Scout](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/docker-scout.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/docker-scout.yml)
 [![slsa-badge](https://slsa.dev/images/gh-badge-level3.svg?color=blue)](https://slsa.dev)
 [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
-🐳 **Clang Tools Docker Image**: This Docker image comes pre-installed with essential clang tools, including `clang-format` and `clang-tidy`.
+<!--[![GitHub Repo](https://img.shields.io/badge/GitHub%20Repo-URL-blue?logo=github)](https://github.com/cpp-linter/clang-tools-docker)-->
+
+This Docker image comes pre-installed with essential clang tools, including `clang-format` and `clang-tidy`.
 
 All images support `linux/amd64` and `linux/arm64` platforms.
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,69 @@
 # Clang Tools Docker image
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/xianpengshen/clang-tools)](https://hub.docker.com/r/xianpengshen/clang-tools)
+[![Docker Image Size](https://img.shields.io/docker/image-size/xianpengshen/clang-tools/22)](https://hub.docker.com/r/xianpengshen/clang-tools/tags)
 [![GitHub Repo](https://img.shields.io/badge/GitHub%20Repo-URL-blue?logo=github)](https://github.com/cpp-linter/clang-tools-docker)
-![Maintenance](https://img.shields.io/maintenance/yes/2026)
 [![CI](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/CI.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/CI.yml)
 [![Docker Scout](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/docker-scout.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/docker-scout.yml)
 [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 🐳 **Clang Tools Docker Image**: This Docker image comes pre-installed with essential clang tools, including `clang-format` and `clang-tidy`.
 
+All images support `linux/amd64` and `linux/arm64` platforms.
+
 You can access all available  Clang Tools Docker images via [Docker Hub registry](https://hub.docker.com/r/xianpengshen/clang-tools) or [GitHub Packages registry](https://github.com/cpp-linter/clang-tools-docker/pkgs/container/clang-tools).
 
 ## Supported Tags and Dockerfile links
 
-* [`all`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile.all) (Supports versions of clang-tools includes `22`, `21`, `20`, `19`, `18`, `17`, `16`, `15`, `14`, `13`, `12`, `11`, `10`)
-* [`22`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`22-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile.alpine)
-* [`21`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`21-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile.alpine)
-* [`20`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`20-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile.alpine)
-* [`19`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`19-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile.alpine)
-* [`18`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`18-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile.alpine)
-* [`17`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`17-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile.alpine)
-* [`16`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`16-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile.alpine)
-* [`15`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`14`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`13`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`12`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`11`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`10`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`9`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`8`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
-* [`7`](https://github.com/cpp-linter/clang-tools-docker/blob/master/Dockerfile)
+* [`all`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile.all) (Supports versions of clang-tools includes `21`, `20`, `19`, `18`, `17`, `16`, `15`, `14`, `13`, `12`, `11`, `10`, `9`)
+* [`22`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`22-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile.alpine)
+* [`21`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`21-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile.alpine)
+* [`20`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`20-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile.alpine)
+* [`19`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`19-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile.alpine)
+* [`18`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`18-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile.alpine)
+* [`17`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`17-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile.alpine)
+* [`16`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`16-alpine`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile.alpine)
+* [`15`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`14`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`13`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`12`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`11`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`10`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`9`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`8`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+* [`7`](https://github.com/cpp-linter/clang-tools-docker/blob/main/Dockerfile)
+
+## Supply Chain Security
+
+All images are signed with [cosign](https://github.com/sigstore/cosign) (keyless, via GitHub Actions OIDC) and come with an [SBOM](https://www.cisa.gov/sbom) (Software Bill of Materials, SPDX format) generated by [Syft](https://github.com/anchore/syft).
+
+### Verify image signature
+
+```bash
+cosign verify \
+  --certificate-identity-regexp 'https://github.com/cpp-linter/clang-tools-docker/.github/workflows/CI.yml@refs/heads/main' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  xianpengshen/clang-tools:22
+```
+
+### Download SBOM
+
+```bash
+cosign download sbom xianpengshen/clang-tools:22
+```
+
+Or use `docker buildx imagetools inspect`:
+
+```bash
+docker buildx imagetools inspect xianpengshen/clang-tools:22 --format '{{ json .SBOM }}'
+```
 
 ## How to use clang-tools Docker images
 
@@ -47,7 +74,7 @@ You can access all available  Clang Tools Docker images via [Docker Hub registry
 $ docker run xianpengshen/clang-tools:19 clang-format --version
 Ubuntu clang-format version 19.1.0 (1ubuntu1)
 # Format code (helloworld.c in the demo directory)
-$ docker run -v $PWD:/src xianpengshen/clang-tools:19 clang-format --dry-run -i helloworld.c
+$ docker run -v $PWD:/src xianpengshen/clang-tools:19 clang-format -i helloworld.c
 
 # Check clang-tidy version
 $ docker run xianpengshen/clang-tools:19 clang-tidy --version
@@ -59,10 +86,10 @@ $ docker run -v $PWD:/src xianpengshen/clang-tools:19 clang-tidy helloworld.c \
 -checks=boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,clang-analyzer-cplusplus-*,clang-analyzer-*,cppcoreguidelines-*
 ```
 
-### As base image in [`Dockerfile`](https://github.com/cpp-linter/clang-tools-docker/blob/master/demo/Dockerfile)
+### As base image in [`Dockerfile`](https://github.com/cpp-linter/clang-tools-docker/blob/main/demo/Dockerfile)
 
 ```Dockerfile
-FROM xianpengshen/clang-tools:19
+FROM xianpengshen/clang-tools:17
 
 WORKDIR /src
 
@@ -80,7 +107,7 @@ $ docker build -t clang-tools .
 $ docker run clang-tools clang-format --version
 Ubuntu clang-format version 17.0.2 (1~exp1ubuntu2.1)
 # Format code
-$ docker run clang-tools clang-format --dry-run -i helloworld.c
+$ docker run clang-tools clang-format -i helloworld.c
 
 # Check clang-tidy version
 $ docker run clang-tools clang-tidy --version
@@ -97,4 +124,4 @@ To provide feedback (requesting a feature or reporting a bug) please post to [is
 
 ## License
 
-[Apache License](https://github.com/cpp-linter/clang-tools-docker/blob/master/LICENSE)
+[Apache License](https://github.com/cpp-linter/clang-tools-docker/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![CI](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/CI.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/CI.yml)
 [![Docker Scout](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/docker-scout.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/docker-scout.yml)
 [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
+[![Cosign Signed](https://img.shields.io/badge/cosign-signed-brightgreen?logo=sigstore)](https://github.com/sigstore/cosign)
+[![SBOM](https://img.shields.io/badge/SBOM-SPDX-blue)](https://www.cisa.gov/sbom)
+[![SLSA 3](https://img.shields.io/badge/SLSA-3-yellow)](https://slsa.dev)
 
 🐳 **Clang Tools Docker Image**: This Docker image comes pre-installed with essential clang tools, including `clang-format` and `clang-tidy`.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 [![Cosign Signed](https://img.shields.io/badge/cosign-signed-brightgreen?logo=sigstore)](https://github.com/sigstore/cosign)
 [![SBOM](https://img.shields.io/badge/SBOM-SPDX-blue)](https://www.cisa.gov/sbom)
-[![SLSA 3](https://img.shields.io/badge/SLSA-3-yellow)](https://slsa.dev)
+[![slsa-badge](https://slsa.dev/images/gh-badge-level3.svg?color=blue)](https://slsa.dev)
 
 🐳 **Clang Tools Docker Image**: This Docker image comes pre-installed with essential clang tools, including `clang-format` and `clang-tidy`.
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@
 [![GitHub Repo](https://img.shields.io/badge/GitHub%20Repo-URL-blue?logo=github)](https://github.com/cpp-linter/clang-tools-docker)
 [![CI](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/CI.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/CI.yml)
 [![Docker Scout](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/docker-scout.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-docker/actions/workflows/docker-scout.yml)
-[![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
-[![Cosign Signed](https://img.shields.io/badge/cosign-signed-brightgreen?logo=sigstore)](https://github.com/sigstore/cosign)
-[![SBOM](https://img.shields.io/badge/SBOM-SPDX-blue)](https://www.cisa.gov/sbom)
 [![slsa-badge](https://slsa.dev/images/gh-badge-level3.svg?color=blue)](https://slsa.dev)
+[![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 🐳 **Clang Tools Docker Image**: This Docker image comes pre-installed with essential clang tools, including `clang-format` and `clang-tidy`.
 


### PR DESCRIPTION
## Summary

This PR adds supply chain security to the Docker image publishing pipeline:

### Changes

**1. SBOM + SLSA Provenance (via buildx attestation)**
- Added `--set "*.attest=type=sbom"` and `--set "*.attest=type=provenance,mode=max"` to the `docker buildx bake --push` command
- Each published image now automatically gets an SPDX-format SBOM generated by Syft
- SLSA provenance attestation documents the build environment and inputs

**2. Cosign Keyless Signing**
- Added `sigstore/cosign-installer@v3.11.0` step
- Signs each image on both Docker Hub and GHCR using GitHub Actions OIDC (no key management needed)
- Added `id-token: write` permission for OIDC token access

**3. README Documentation**
- Added 'Supply Chain Security' section with:
  - `cosign verify` command for end users
  - `cosign download sbom` / `docker buildx imagetools inspect` for SBOM retrieval

### Impact
- Only affects the `workflow_dispatch` publish path (manual releases), not PR/CI builds
- No changes to the build or test logic
- Fully backwards compatible

### Verification
After merge, users can verify images:
```bash
cosign verify \
  --certificate-identity-regexp 'https://github.com/cpp-linter/clang-tools-docker/.github/workflows/CI.yml@refs/heads/main' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
  xianpengshen/clang-tools:22

cosign download sbom xianpengshen/clang-tools:22
```